### PR TITLE
fix: %f modifier

### DIFF
--- a/src/QRInvoice.php
+++ b/src/QRInvoice.php
@@ -252,7 +252,7 @@ class QRInvoice
 	 */
 	public function setAmount($amount)
 	{
-		$this->spd_keys['AM'] = $this->sid_keys['AM'] = sprintf('%.2f', $amount);
+		$this->spd_keys['AM'] = $this->sid_keys['AM'] = sprintf('%.2F', $amount);
 
 		return $this;
 	}


### PR DESCRIPTION
When using the `cs_CZ.UTF-8` locale with the `%f` flag, the script outputs a decimal float with a comma (,). However, it should use a dot (.) as the decimal separator. I believe we should use %F instead, as per the [documentation](https://www.php.net/manual/en/function.sprintf.php).

Example:

```
setlocale(LC_ALL, 'cs_CZ.UTF-8');
echo(sprintf("%.2f", 13.332)); // Outputs: 13,33
echo(sprintf("%.2F", 13.332)); // Outputs: 13.33
```